### PR TITLE
Add FLAG_ACTIVITY_RESET_TASK_IF_NEEDED when launching activities

### DIFF
--- a/app/src/main/java/com/hayaisoftware/launcher/LaunchableActivity.java
+++ b/app/src/main/java/com/hayaisoftware/launcher/LaunchableActivity.java
@@ -67,7 +67,7 @@ public class LaunchableActivity{
         }
         final Intent launchIntent = new Intent(Intent.ACTION_MAIN);
         launchIntent.addCategory(Intent.CATEGORY_LAUNCHER);
-        launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
         launchIntent.setComponent(mComponentName);
         return launchIntent;
     }


### PR DESCRIPTION
This adds the `Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED` flag when launching activities, which should be set when starting activities from a launcher app.  See http://stackoverflow.com/questions/18203278/proper-flags-to-start-an-activity-from-a-launcher

(More detailed explanations: http://stackoverflow.com/questions/29321261/what-are-the-differences-between-flag-activity-reset-task-if-needed-and-flag-act )

This PR fixes the following problem where apps will get multiple instances of their activity stacked up when launched from HayaiLauncher (Gmail is a notable example of an app that this happens to):
1. Launch Gmail from HayaiLauncher
2. Return to HayaiLauncher with the Home button
3. Launch Gmail again
4. Press Back
5. You end up on a second Gmail instance, when I would expect to end up on HayaiLauncher

With the PR, HayaiLauncher behaves like other launchers, and no matter how many times you reopen Gmail, there is only a single instance of it's main activity.

This is possibly related to #83 and this may fix or improve the situation described there.
