### PR TITLE
Apps On sdCards show up (fix of #89)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,12 +27,8 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <action android:name="android.intent.action.ASSIST" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
-                
-
                 <category android:name="android.intent.category.HOME" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
@@ -47,6 +43,16 @@
             android:theme="@style/AppSettingsTheme"
             android:label="@string/title_activity_about" >
         </activity>
+
+        <receiver
+            android:name=".SdCardMountedReceiver"
+            android:enabled="true"
+            >
+            <intent-filter>
+                <action android:name="android.intent.action.EXTERNAL_APPLICATIONS_AVAILABLE" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:targetSdkVersion="22" />
 
     <!-- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/hayaisoftware/launcher/SdCardMountedReceiver.java
+++ b/app/src/main/java/com/hayaisoftware/launcher/SdCardMountedReceiver.java
@@ -5,29 +5,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.util.Log;
-import com.hayaisoftware.launcher.activities.SearchActivity;
-
-/**
- * Created by thereiskeks on 04.02.2017.
- */
 
 public class SdCardMountedReceiver extends BroadcastReceiver {
 
-    SearchActivity callback;
-    public SdCardMountedReceiver(SearchActivity callback)
-    {
-        this.callback = callback;
-    }
     public void onReceive(Context context, Intent intent) {
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
-        Log.e("Received thing","sd card is mounted");
 
         // this is the list of newly available apps
         String[] packageChangedNames = intent.getExtras().getStringArray(Intent.EXTRA_CHANGED_PACKAGE_LIST);
@@ -46,10 +27,7 @@ public class SdCardMountedReceiver extends BroadcastReceiver {
                 names += " " + availablePackage;
                 editor.putString("package_changed_name", names.trim());
             }
-
         }
-
         editor.apply();
     }
-
 }

--- a/app/src/main/java/com/hayaisoftware/launcher/SdCardMountedReceiver.java
+++ b/app/src/main/java/com/hayaisoftware/launcher/SdCardMountedReceiver.java
@@ -1,0 +1,55 @@
+package com.hayaisoftware.launcher;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.util.Log;
+import com.hayaisoftware.launcher.activities.SearchActivity;
+
+/**
+ * Created by thereiskeks on 04.02.2017.
+ */
+
+public class SdCardMountedReceiver extends BroadcastReceiver {
+
+    SearchActivity callback;
+    public SdCardMountedReceiver(SearchActivity callback)
+    {
+        this.callback = callback;
+    }
+    public void onReceive(Context context, Intent intent) {
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+        Log.e("Received thing","sd card is mounted");
+
+        // this is the list of newly available apps
+        String[] packageChangedNames = intent.getExtras().getStringArray(Intent.EXTRA_CHANGED_PACKAGE_LIST);
+        Log.d("SD_Card Mounted", packageChangedNames.length+" newly available packages");
+
+        final SharedPreferences sharedPreferences = context.getSharedPreferences(
+                context.getPackageName() + "_preferences",
+                Context.MODE_PRIVATE);
+        final SharedPreferences.Editor editor = sharedPreferences.edit();
+        String names =sharedPreferences.getString("package_changed_names","");
+
+        for(String availablePackage : packageChangedNames)
+        {
+            // add the changed package to the list of changed packages
+            if(!names.contains(availablePackage)) {
+                names += " " + availablePackage;
+                editor.putString("package_changed_name", names.trim());
+            }
+
+        }
+
+        editor.apply();
+    }
+
+}

--- a/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
+++ b/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
@@ -650,7 +650,8 @@ public class SearchActivity extends Activity
         if (mImageLoadingConsumersManager != null)
             mImageLoadingConsumersManager.destroyAllConsumers(false);
         unregisterReceiver(mPackageChangedReceiver);
-        Log.d("HayaiLauncher", "Hayai is ded");
+        unregisterReceiver(mSdCardChangedReceiver);
+        Log.d("HayaiLauncher", "Hayai is dead");
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
+++ b/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
@@ -230,12 +230,7 @@ public class SearchActivity extends Activity
         mPackageChangedReceiver = new PackageChangedReceiver();
         registerReceiver(mPackageChangedReceiver, filter);
 
-        // broadcast receiver that listens for sd card mounting
-        final IntentFilter sdCradFilter = new IntentFilter();
-        sdCradFilter.addAction(Intent.ACTION_EXTERNAL_APPLICATIONS_AVAILABLE);
-        //sdCradFilter.addAction(Intent.ACTION_EXTERNAL_APPLICATIONS_UNAVAILABLE);
-        mSdCardChangedReceiver = new SdCardMountedReceiver();
-        registerReceiver(mSdCardChangedReceiver, sdCradFilter);
+
 
         loadLaunchableApps();
 

--- a/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
+++ b/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
@@ -64,6 +64,7 @@ import com.hayaisoftware.launcher.LaunchableActivityPrefs;
 import com.hayaisoftware.launcher.LoadLaunchableActivityTask;
 import com.hayaisoftware.launcher.PackageChangedReceiver;
 import com.hayaisoftware.launcher.R;
+import com.hayaisoftware.launcher.SdCardMountedReceiver;
 import com.hayaisoftware.launcher.ShortcutNotificationManager;
 import com.hayaisoftware.launcher.StatusBarColorHelper;
 import com.hayaisoftware.launcher.Trie;
@@ -111,6 +112,7 @@ public class SearchActivity extends Activity
     private View mClearButton;
     private int mNumOfCores;
     private BroadcastReceiver mPackageChangedReceiver;
+    private BroadcastReceiver mSdCardChangedReceiver;
 
     private Comparator<LaunchableActivity> mPinToTopComparator;
     private Comparator<LaunchableActivity> mRecentOrderComparator;
@@ -218,6 +220,7 @@ public class SearchActivity extends Activity
 
         mNumOfCores = Runtime.getRuntime().availableProcessors();
 
+        // broadcast receiver that listens for app changes
         final IntentFilter filter = new IntentFilter();
         filter.addAction(Intent.ACTION_PACKAGE_ADDED);
         filter.addAction(Intent.ACTION_PACKAGE_CHANGED);
@@ -226,6 +229,13 @@ public class SearchActivity extends Activity
         filter.addDataScheme("package");
         mPackageChangedReceiver = new PackageChangedReceiver();
         registerReceiver(mPackageChangedReceiver, filter);
+
+        // broadcast receiver that listens for sd card mounting
+        final IntentFilter sdCradFilter = new IntentFilter();
+        sdCradFilter.addAction(Intent.ACTION_EXTERNAL_APPLICATIONS_AVAILABLE);
+        //sdCradFilter.addAction(Intent.ACTION_EXTERNAL_APPLICATIONS_UNAVAILABLE);
+        mSdCardChangedReceiver = new SdCardMountedReceiver(this);
+        registerReceiver(mSdCardChangedReceiver, sdCradFilter);
 
         loadLaunchableApps();
 

--- a/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
+++ b/app/src/main/java/com/hayaisoftware/launcher/activities/SearchActivity.java
@@ -234,7 +234,7 @@ public class SearchActivity extends Activity
         final IntentFilter sdCradFilter = new IntentFilter();
         sdCradFilter.addAction(Intent.ACTION_EXTERNAL_APPLICATIONS_AVAILABLE);
         //sdCradFilter.addAction(Intent.ACTION_EXTERNAL_APPLICATIONS_UNAVAILABLE);
-        mSdCardChangedReceiver = new SdCardMountedReceiver(this);
+        mSdCardChangedReceiver = new SdCardMountedReceiver();
         registerReceiver(mSdCardChangedReceiver, sdCradFilter);
 
         loadLaunchableApps();


### PR DESCRIPTION
I added a receiver that catches sdCard mounts on boot and during runtime. 
This fixes Issue #89.

## To test the functionality:
1. Move a app to sdCard 
2. Eject sdCard
3. Reboot
4. App should not be visible
5. Mount sdCard
6. App should turn up after a minute or so

## or:
1. Move a app to sdCard
2. Reboot
3. App should be visible after a minute or so
